### PR TITLE
add QuaZip 1.3 include path

### DIFF
--- a/modmanager.pro
+++ b/modmanager.pro
@@ -417,6 +417,7 @@ unix {
   }
   LIBS += -L$$quote(/usr/local/lib) -laria2
   INCLUDEPATH += \
+      /usr/include/QuaZip-Qt5-1.3/quazip \
       /usr/include/QuaZip-Qt5-1.2/quazip \
       /usr/include/QuaZip-Qt5-1.1/quazip \
       /usr/include/quazip


### PR DESCRIPTION
As the QuaZip package on Arch Linux has been updated to 1.3, the original include path of /usr/include/QuaZip-Qt5-1.2/quazip/ is no longer valid. Thus, according to the same approach in 3b50faabcf490d011ae52ca668c6ace522568894, I'm adding the 1.3 include path to the build file.

This patch should fix building on Arch Linux or any Unix operating systems that do not offer old include paths. This fixes building the modmanager-git AUR package.

For the modmanager AUR package, I had also added this patch to the PKGBUILD because v1.1.0 is already published.

I recommend you to use pkg-config instead of hard-coding the include path as the path may be changed later with QuaZip upgrades. Thank you.